### PR TITLE
Fix error response after several retries

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,12 @@ function setup(fetch) {
 
     return retry(async (bail, attempt) => {
       const {method = 'GET'} = opts;
+      const isRetry = attempt < retryOpts.retries;
       try {
         // this will be retried
         const res = await fetch(url, opts);
         debug('status %d', res.status);
-        if (res.status >= 500 && res.status < 600) {
+        if (res.status >= 500 && res.status < 600 && isRetry) {
           const err = new Error(res.statusText);
           err.code = err.status = err.statusCode = res.status;
           err.url = url;
@@ -45,7 +46,7 @@ function setup(fetch) {
           return res;
         }
       } catch (err) {
-        debug(`${method} ${url} error (${err.status}). ${attempt < MAX_RETRIES ? 'retrying' : ''}`, err);
+        debug(`${method} ${url} error (${err.status}). ${isRetry ? 'retrying' : ''}`, err);
         throw err;
       }
     }, retryOpts)

--- a/test.js
+++ b/test.js
@@ -59,15 +59,12 @@ test('accepts a custom onRetry option', async () => {
 
     server.listen(async () => {
       const {port} = server.address();
-      try {
-        await retryFetch(`http://127.0.0.1:${port}`, opts);
-      } catch (err) {
-        expect(opts.onRetry.mock.calls.length).toBe(3);
-        expect(opts.onRetry.mock.calls[0][0]).toEqual(err);
-        expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
-        expect(await err.status).toBe(500);
-        server.close();
-      }
+      const res = await retryFetch(`http://127.0.0.1:${port}`, opts);
+      expect(opts.onRetry.mock.calls.length).toBe(2);
+      expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
+      expect(res.status).toBe(500);
+      server.close();
       return resolve();
     });
     server.on('error', reject);

--- a/test.js
+++ b/test.js
@@ -28,7 +28,7 @@ test('retries upon 500', async () => {
   });
 });
 
-test('fails on >MAX_RETRIES', async () => {
+test('resolves on >MAX_RETRIES', async () => {
   const server = createServer((req, res) => {
     res.writeHead(500);
     res.end();
@@ -42,9 +42,8 @@ test('fails on >MAX_RETRIES', async () => {
       } catch (err) {
         expect(await err.status).toBe(500);
         server.close();
-        return resolve();
       }
-      reject(new Error('must fail'));
+      return resolve();
     });
     server.on('error', reject);
   });
@@ -71,9 +70,8 @@ test('accepts a custom onRetry option', async () => {
         expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
         expect(await err.status).toBe(500);
         server.close();
-        return resolve();
       }
-      reject(new Error('must fail'));
+      return resolve();
     });
     server.on('error', reject);
   });

--- a/test.js
+++ b/test.js
@@ -37,12 +37,9 @@ test('resolves on >MAX_RETRIES', async () => {
   return new Promise((resolve, reject) => {
     server.listen(async () => {
       const {port} = server.address();
-      try {
-        await retryFetch(`http://127.0.0.1:${port}`);
-      } catch (err) {
-        expect(await err.status).toBe(500);
-        server.close();
-      }
+      const res = await retryFetch(`http://127.0.0.1:${port}`);
+      expect(res.status).toBe(500);
+      server.close();
       return resolve();
     });
     server.on('error', reject);


### PR DESCRIPTION
This change makes sure we return the response when we receive the same 500-600 status code after x number of retries.

This will be a semver major breaking change.