### PR TITLE
Improve defaults retry configuration and bump async-retry

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const debug = require('debug')('fetch-retry');
 
 // retry settings
 const MIN_TIMEOUT = 10;
-const MAX_RETRIES = 3;
-const FACTOR = 5;
+const MAX_RETRIES = 5;
+const FACTOR = 6;
 
 module.exports = setup;
 
@@ -15,7 +15,8 @@ function setup(fetch) {
 
   function fetchRetry(url, opts = {}) {
     const retryOpts = Object.assign({
-      // timeouts will be [ 10, 50, 250 ]
+      // timeouts will be [10, 60, 360, 2160, 12960]
+      // (before randomization is added)
       minTimeout: MIN_TIMEOUT,
       retries: MAX_RETRIES,
       factor: FACTOR,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node-fetch": "*"
   },
   "dependencies": {
-    "async-retry": "^1.1.3",
+    "async-retry": "^1.3.1",
     "debug": "^3.1.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,11 +138,12 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
 
-async-retry@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.1.3.tgz#1be664783337a0614999d543009a3b6e0de3609d"
+async-retry@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.1.tgz#139f31f8ddce50c0870b0ba558a6079684aaed55"
+  integrity sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
   dependencies:
-    retry "0.10.1"
+    retry "0.12.0"
 
 async@^1.4.0:
   version "1.5.2"
@@ -2079,9 +2080,10 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-retry@0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+retry@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
 right-align@^0.1.1:
   version "0.1.3"


### PR DESCRIPTION
Change default retry configuration to:
- 10 ms min timeout
- 5 retries
- factor 6 for exponential backoff

Which means that (as stated in code comments):
```js
// timeouts will be [10, 60, 360, 2160, 12960]
// (before randomization is added)
```