### PR TITLE
Fix retries option is not fully respected, fix not to throw error cau…

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,19 +3,19 @@ const debug = require('debug')('fetch-retry');
 
 // retry settings
 const MIN_TIMEOUT = 10;
-const MAX_RETRIES = 5;
+const MAX_RETRIES = 4;
 const FACTOR = 6;
 
-module.exports = setup;
+module.exports = exports = setup;
 
 function setup(fetch) {
   if (!fetch) {
     fetch = require('node-fetch');
   }
 
-  function fetchRetry(url, opts = {}) {
+  async function fetchRetry(url, opts = {}) {
     const retryOpts = Object.assign({
-      // timeouts will be [10, 60, 360, 2160, 12960]
+      // timeouts will be [10, 60, 360, 2160, ...]
       // (before randomization is added)
       minTimeout: MIN_TIMEOUT,
       retries: MAX_RETRIES,
@@ -31,26 +31,30 @@ function setup(fetch) {
       }
     }
 
-    return retry(async (bail, attempt) => {
-      const {method = 'GET'} = opts;
-      const isRetry = attempt < retryOpts.retries;
-      try {
-        // this will be retried
-        const res = await fetch(url, opts);
-        debug('status %d', res.status);
-        if (res.status >= 500 && res.status < 600 && isRetry) {
-          const err = new Error(res.statusText);
-          err.code = err.status = err.statusCode = res.status;
-          err.url = url;
+    try {
+      return await retry(async (bail, attempt) => {
+        const {method = 'GET'} = opts;
+        try {
+          // this will be retried
+          const res = await fetch(url, opts);
+          debug('status %d', res.status);
+          if (res.status >= 500 && res.status < 600) {
+            throw new ResponseError(res);
+          } else {
+            return res;
+          }
+        } catch (err) {
+          const isRetry = attempt <= retryOpts.retries;
+          debug(`${method} ${url} error (${err.status}). ${isRetry ? 'retrying' : ''}`, err);
           throw err;
-        } else {
-          return res;
         }
-      } catch (err) {
-        debug(`${method} ${url} error (${err.status}). ${isRetry ? 'retrying' : ''}`, err);
-        throw err;
+      }, retryOpts);
+    } catch (err) {
+      if (err instanceof ResponseError) {
+        return err.res;
       }
-    }, retryOpts)
+      throw err;
+    }
   }
 
   for (const key of Object.keys(fetch)) {
@@ -60,3 +64,17 @@ function setup(fetch) {
 
   return fetchRetry;
 }
+
+class ResponseError extends Error {
+  constructor(res) {
+    super(res.statusText);
+    this.name = this.constructor.name;
+    this.res = res;
+
+    // backward compat
+    this.code = this.status = this.statusCode = res.status;
+    this.url = res.url;
+  }
+}
+
+exports.ResponseError = ResponseError;

--- a/index.js
+++ b/index.js
@@ -68,6 +68,11 @@ function setup(fetch) {
 class ResponseError extends Error {
   constructor(res) {
     super(res.statusText);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ResponseError);
+    }
+
     this.name = this.constructor.name;
     this.res = res;
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const debug = require('debug')('fetch-retry');
 
 // retry settings
 const MIN_TIMEOUT = 10;
-const MAX_RETRIES = 4;
+const MAX_RETRIES = 5;
 const FACTOR = 6;
 
 module.exports = exports = setup;
@@ -15,7 +15,7 @@ function setup(fetch) {
 
   async function fetchRetry(url, opts = {}) {
     const retryOpts = Object.assign({
-      // timeouts will be [10, 60, 360, 2160, ...]
+      // timeouts will be [10, 60, 360, 2160, 12960]
       // (before randomization is added)
       minTimeout: MIN_TIMEOUT,
       retries: MAX_RETRIES,

--- a/readme.md
+++ b/readme.md
@@ -28,13 +28,13 @@ Some errors are very common in production (like the underlying `Socket`
 yielding `ECONNRESET`), and can easily and instantly be remediated
 by retrying.
 
-The default behavior of `fetch-retry` is to attempt retries **10**, **50**
-and **250** milliseconds (a total of 3 retries) after
+The default behavior of `fetch-retry` is to attempt retries **10**, **60**
+**360** and **2160** milliseconds (a total of 4 retries) after
 a *network error* or *5xx* error occur.
 
 The idea is to provide a sensible default: most applications should
 continue to perform correctly with a worst case scenario of a given
-request having an additional 250ms overhead. 
+request having an additional 2160ms overhead. 
 
 On the other hand, most applications that use `fetch-retry` instead of
 vanilla `fetch` should see lower rates of common errors and fewer 'glitches'

--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,12 @@ yielding `ECONNRESET`), and can easily and instantly be remediated
 by retrying.
 
 The default behavior of `fetch-retry` is to attempt retries **10**, **60**
-**360** and **2160** milliseconds (a total of 4 retries) after
+**360**, **2160** and **12960** milliseconds (a total of 5 retries) after
 a *network error* or *5xx* error occur.
 
 The idea is to provide a sensible default: most applications should
 continue to perform correctly with a worst case scenario of a given
-request having an additional 2160ms overhead. 
+request having an additional 15550ms overhead.
 
 On the other hand, most applications that use `fetch-retry` instead of
 vanilla `fetch` should see lower rates of common errors and fewer 'glitches'

--- a/test.js
+++ b/test.js
@@ -17,14 +17,15 @@ test('retries upon 500', async () => {
 
   return new Promise((resolve, reject) => {
     server.listen(async () => {
-      const {port} = server.address();
       try {
+        const {port} = server.address();
         const res = await retryFetch(`http://127.0.0.1:${port}`);
         expect(await res.text()).toBe('ha');
-        server.close();
         resolve();
       } catch (err) {
         reject(err);
+      } finally {
+        server.close();
       }
     });
     server.on('error', reject);
@@ -39,11 +40,14 @@ test('resolves on >MAX_RETRIES', async () => {
 
   return new Promise((resolve, reject) => {
     server.listen(async () => {
-      const {port} = server.address();
-      const res = await retryFetch(`http://127.0.0.1:${port}`);
-      expect(res.status).toBe(500);
-      server.close();
-      return resolve();
+      try {
+        const {port} = server.address();
+        const res = await retryFetch(`http://127.0.0.1:${port}`);
+        expect(res.status).toBe(500);
+        return resolve();
+      } finally {
+        server.close();
+      }
     });
     server.on('error', reject);
   });
@@ -61,14 +65,17 @@ test('accepts a custom onRetry option', async () => {
     }
 
     server.listen(async () => {
-      const {port} = server.address();
-      const res = await retryFetch(`http://127.0.0.1:${port}`, opts);
-      expect(opts.onRetry.mock.calls.length).toBe(4);
-      expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(ResponseError);
-      expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
-      expect(res.status).toBe(500);
-      server.close();
-      return resolve();
+      try {
+        const {port} = server.address();
+        const res = await retryFetch(`http://127.0.0.1:${port}`, opts);
+        expect(opts.onRetry.mock.calls.length).toBe(4);
+        expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(ResponseError);
+        expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
+        expect(res.status).toBe(500);
+        return resolve();
+      } finally {
+        server.close();
+      }
     });
     server.on('error', reject);
   });

--- a/test.js
+++ b/test.js
@@ -1,5 +1,8 @@
 const {createServer} =  require('http');
-const retryFetch = require('./index')();
+const setup = require('./index');
+
+const { ResponseError } = setup;
+const retryFetch = setup();
 
 test('retries upon 500', async () => {
   let i = 0
@@ -60,8 +63,8 @@ test('accepts a custom onRetry option', async () => {
     server.listen(async () => {
       const {port} = server.address();
       const res = await retryFetch(`http://127.0.0.1:${port}`, opts);
-      expect(opts.onRetry.mock.calls.length).toBe(2);
-      expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(opts.onRetry.mock.calls.length).toBe(4);
+      expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(ResponseError);
       expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
       expect(res.status).toBe(500);
       server.close();

--- a/test.js
+++ b/test.js
@@ -42,7 +42,11 @@ test('resolves on >MAX_RETRIES', async () => {
     server.listen(async () => {
       try {
         const {port} = server.address();
-        const res = await retryFetch(`http://127.0.0.1:${port}`);
+        const res = await retryFetch(`http://127.0.0.1:${port}`, {
+          retry: {
+            retries: 3
+          }
+        });
         expect(res.status).toBe(500);
         return resolve();
       } finally {
@@ -61,14 +65,17 @@ test('accepts a custom onRetry option', async () => {
 
   return new Promise((resolve, reject) => {
     const opts = {
-      onRetry: jest.fn()
+      onRetry: jest.fn(),
+      retry: {
+        retries: 3
+      }
     }
 
     server.listen(async () => {
       try {
         const {port} = server.address();
         const res = await retryFetch(`http://127.0.0.1:${port}`, opts);
-        expect(opts.onRetry.mock.calls.length).toBe(4);
+        expect(opts.onRetry.mock.calls.length).toBe(3);
         expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(ResponseError);
         expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
         expect(res.status).toBe(500);


### PR DESCRIPTION
…sed by error status

- Currently, it retries only the `retries` option - 1 times. This PR fixes to respect the option.
- Changes default the `retries` option from `5` to `4` because of the above problem and waiting for `12960 ` is too long.
- Fix not to throw an error when it's because of `res.status >= 500`. It used to happen when the last error is like `ECONNREFUSED` but the main error (the most frequent error) is `res.status >= 500` )
- Fix server is not closed upon error on tests