### PR TITLE
Retry on 429 and respect the Retry-After header

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,12 @@ function setup(fetch) {
           // this will be retried
           const res = await fetch(url, opts);
           debug('status %d', res.status);
-          if (res.status >= 500 && res.status < 600) {
+          if ((res.status >= 500 && res.status < 600) || res.status === 429) {
+            // NOTE: doesn't support http-date format
+            const retryAfter = parseInt(res.headers.get('retry-after'), 10);
+            if (retryAfter) {
+              await new Promise(r => setTimeout(r, retryAfter * 1e3));
+            }
             throw new ResponseError(res);
           } else {
             return res;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const debug = require('debug')('fetch-retry');
 // retry settings
 const MIN_TIMEOUT = 10;
 const MAX_RETRIES = 5;
+const MAX_RETRY_AFTER = 20;
 const FACTOR = 6;
 
 module.exports = exports = setup;
@@ -20,6 +21,7 @@ function setup(fetch) {
       minTimeout: MIN_TIMEOUT,
       retries: MAX_RETRIES,
       factor: FACTOR,
+      maxRetryAfter: MAX_RETRY_AFTER,
     }, opts.retry);
 
     if (opts.onRetry) {
@@ -42,7 +44,11 @@ function setup(fetch) {
             // NOTE: doesn't support http-date format
             const retryAfter = parseInt(res.headers.get('retry-after'), 10);
             if (retryAfter) {
-              await new Promise(r => setTimeout(r, retryAfter * 1e3));
+              if (retryAfter > retryOpts.maxRetryAfter) {
+                return res;
+              } else {
+                await new Promise(r => setTimeout(r, retryAfter * 1e3));
+              }
             }
             throw new ResponseError(res);
           } else {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const debug = require('debug')('fetch-retry');
 
 // retry settings
 const MIN_TIMEOUT = 10;
-const MAX_RETRIES = 4;
+const MAX_RETRIES = 5;
 const FACTOR = 6;
 
 module.exports = exports = setup;
@@ -15,7 +15,7 @@ function setup(fetch) {
 
   async function fetchRetry(url, opts = {}) {
     const retryOpts = Object.assign({
-      // timeouts will be [10, 60, 360, 2160, ...]
+      // timeouts will be [10, 60, 360, 2160, 12960]
       // (before randomization is added)
       minTimeout: MIN_TIMEOUT,
       retries: MAX_RETRIES,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const debug = require('debug')('fetch-retry');
 
 // retry settings
 const MIN_TIMEOUT = 10;
-const MAX_RETRIES = 5;
+const MAX_RETRIES = 4;
 const FACTOR = 6;
 
 module.exports = exports = setup;
@@ -15,7 +15,7 @@ function setup(fetch) {
 
   async function fetchRetry(url, opts = {}) {
     const retryOpts = Object.assign({
-      // timeouts will be [10, 60, 360, 2160, 12960]
+      // timeouts will be [10, 60, 360, 2160, ...]
       // (before randomization is added)
       minTimeout: MIN_TIMEOUT,
       retries: MAX_RETRIES,

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,13 @@ module.exports = async () => {
 Make sure to `yarn add @zeit/fetch-retry` in your main package.
 
 Note that you can pass [retry options](https://github.com/zeit/async-retry) to using `opts.retry`.
-We also provide a `opts.onRetry` which is a customized version of `opts.retry.onRetry` and passes
+We also provide a `opts.onRetry` and `opts.retry.maxRetryAfter` options.
+
+`opts.onRetry` is a customized version of `opts.retry.onRetry` and passes
 not only the `error` object in each retry but also the current `opts` object.
+
+`opts.retry.maxRetryAfter` is the max wait time according to the `Retry-After` header.
+If it exceeds the option value, stop retrying and returns the error response. It defaults to `20`.
 
 ## Rationale
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ by retrying.
 
 The default behavior of `fetch-retry` is to attempt retries **10**, **60**
 **360**, **2160** and **12960** milliseconds (a total of 5 retries) after
-a *network error* or *5xx* error occur.
+a *network error*, *429* or *5xx* error occur.
 
 The idea is to provide a sensible default: most applications should
 continue to perform correctly with a worst case scenario of a given

--- a/test.js
+++ b/test.js
@@ -88,7 +88,7 @@ test('accepts a custom onRetry option', async () => {
   });
 })
 
-test('handle the Retry-After header', async () => {
+test('handles the Retry-After header', async () => {
   const server = createServer((req, res) => {
     res.writeHead(429, { 'Retry-After': 1 });
     res.end();
@@ -106,6 +106,35 @@ test('handle the Retry-After header', async () => {
           }
         });
         expect(Date.now() - startedAt).toBeGreaterThanOrEqual(1010);
+        resolve();
+      } catch (err) {
+        reject(err);
+      } finally {
+        server.close();
+      }
+    });
+    server.on('error', reject);
+  });
+});
+
+test('stops retrying when the Retry-After header exceeds the maxRetryAfter option', async () => {
+  const server = createServer((req, res) => {
+    res.writeHead(429, { 'Retry-After': 21 });
+    res.end();
+  });
+
+  return new Promise((resolve, reject) => {
+    const opts = {
+      onRetry: jest.fn(),
+    }
+
+    server.listen(async () => {
+      const {port} = server.address();
+      try {
+        const startedAt = Date.now();
+        const res = await retryFetch(`http://127.0.0.1:${port}`, opts);
+        expect(opts.onRetry.mock.calls.length).toBe(0);
+        expect(res.status).toBe(429);
         resolve();
       } catch (err) {
         reject(err);


### PR DESCRIPTION
Based on https://github.com/zeit/fetch-retry/pull/30

It doesn't support `Retry-After: <http-date>` for now